### PR TITLE
Fix ID creation for file-based migrations on Windows

### DIFF
--- a/file.go
+++ b/file.go
@@ -3,7 +3,6 @@ package schema
 import (
 	"fmt"
 	"io/ioutil"
-	"path"
 	"path/filepath"
 	"strings"
 )
@@ -12,14 +11,14 @@ import (
 // from the filename to make a friendlier Migration ID
 //
 func MigrationIDFromFilename(filename string) string {
-	return strings.TrimSuffix(path.Base(filename), path.Ext(filename))
+	return strings.TrimSuffix(filepath.Base(filename), filepath.Ext(filename))
 }
 
 // MigrationsFromDirectoryPath retrieves a slice of Migrations from the
 // contents of the directory. Only .sql files are read
 func MigrationsFromDirectoryPath(dirPath string) (migrations []*Migration, err error) {
 	migrations = make([]*Migration, 0)
-	filenames, err := filepath.Glob(path.Join(dirPath, "*.sql"))
+	filenames, err := filepath.Glob(filepath.Join(dirPath, "*.sql"))
 	if err != nil {
 		return migrations, err
 	}

--- a/file_test.go
+++ b/file_test.go
@@ -5,6 +5,29 @@ import (
 	"testing"
 )
 
+func TestMigrationIDFromFilename(t *testing.T) {
+	const (
+		sampleID = "2019-01-01 0900 Create Users"
+	)
+	tests := []struct {
+		path string
+		want string
+		name string
+	}{
+		{"c:\\db\\migrations\\"+sampleID+".sql", sampleID, "Windows Path"},
+		{"\\\\server\\db\\migrations\\"+sampleID+".sql", sampleID, "Windows UNC Path"},
+		{"/db/migrations/"+sampleID+".sql", "2019-01-01 0900 Create Users", "Linux Path"},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := MigrationIDFromFilename(test.path)
+			if got != test.want {
+				t.Errorf("%s ID Error, want \"%s\", got \"%s\"", test.name, test.want, got)
+			}
+		})
+	}
+}
+
 func TestMigrationFromFilePath(t *testing.T) {
 	migration, err := MigrationFromFilePath("./example-migrations/2019-01-01 0900 Create Users.sql")
 	if migration.Script != "CREATE TABLE users (id INTEGER NOT NULL PRIMARY KEY);" {


### PR DESCRIPTION
Substitute `filepath` package functions for `path` functions in `file.go`. Added a new test for the `MigrationIDFromFilename` function.

I was unable to get the full test suite to run (under Windows) due to an assignment mismatch in dockertest:

```
github.com/ory/dockertest/docker/pkg/system
..\..\go\pkg\mod\github.com\ory\dockertest@v3.3.5+incompatible
\docker\pkg\system\filesys_windows.go:113:24: cannot use
uintptr(unsafe.Pointer(&sd[0])) (type uintptr) as type
*"golang.org/x/sys/windows".SECURITY_DESCRIPTOR in assignment
```

Closes #1