### PR TITLE
ci: improve automated release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,17 +22,42 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Generate release notes
-        id: notes
-        run: |
-          prev_tag=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || true)
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
-          if [ -n "$prev_tag" ]; then
-            echo "Generating changelog from $prev_tag to $GITHUB_REF_NAME"
-            notes=$(git log --pretty=format:'- %s' "$prev_tag"..HEAD)
+      - name: Extract release notes from README version history
+        id: notes
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          notes=$(python3 <<'PY'
+          import re
+          from pathlib import Path
+
+          version = __import__('os').environ['VERSION']
+          readme = Path('README.md').read_text()
+          pattern = re.compile(
+              rf'^###\s+{re.escape(version)}\s+-.*?\n(.*?)(?=^###\s+|\Z)',
+              re.MULTILINE | re.DOTALL,
+          )
+          match = pattern.search(readme)
+          if match:
+              print(match.group(1).strip())
+          PY
+          )
+
+          if [ -n "$notes" ]; then
+            echo "Found release notes for v$VERSION in README.md"
           else
-            echo "No previous tag found, using all commits"
-            notes=$(git log --pretty=format:'- %s')
+            prev_tag=$(git describe --tags --abbrev=0 HEAD^ 2>/dev/null || true)
+            if [ -n "$prev_tag" ]; then
+              echo "No README entry found; generating notes from $prev_tag to $GITHUB_REF_NAME"
+              notes=$(git log --pretty=format:'- %s' "$prev_tag"..HEAD)
+            else
+              echo "No previous tag found; using all commits for notes"
+              notes=$(git log --pretty=format:'- %s')
+            fi
           fi
 
           {


### PR DESCRIPTION
## Summary
- keep the existing tag-driven GitHub release automation in schema
- make release notes extract the matching version entry from README version history
- fall back to git-log-based notes when a README entry is missing so releases still complete

## Test Plan
- python3 README extraction script for v1.4.0
- /tmp/actionlint-bin/actionlint .github/workflows/release.yml
